### PR TITLE
Support update-alternatives out of the box on Debian and Ubuntu

### DIFF
--- a/install_debian.sh
+++ b/install_debian.sh
@@ -83,13 +83,17 @@ while getopts "d:asmnih" o; do
         a)
             ADD_UA_ENTRY=true
             # Bash getopts doesn't support optional argument values,
-            # so we have to use this ugly hack to support that:
+            # so we have to use this ugly hack to get around that:
             set +u
+            # Temporarily allow unset variables, as this will be
+            # unset in the case that there are no more args left
+            # ie '-a' was the final argument:
             eval "NEXT_OPTION=\${$OPTIND}"
             if [[ ! "${NEXT_OPTION}" =~ - ]]; then
                 PRIORITY="${NEXT_OPTION}"
                 shift 1
             fi
+            # Turn unset-variable checking back on:
             set -u
             ;;
         m)


### PR DESCRIPTION
Update the Debian install script (`install_debian.sh`) to add an entry for `x-terminal-emulator` to the `update-alternatives` list. This will allow the user to choose `st` for their terminal using the standard `update-alternatives` interface, adding the features requested in #1.